### PR TITLE
Update Auth0 search engine to v3

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/auth/Auth0Users.java
+++ b/src/main/java/com/conveyal/datatools/manager/auth/Auth0Users.java
@@ -49,11 +49,11 @@ public class Auth0Users {
         builder.setParameter("page", Integer.toString(page));
         builder.setParameter("include_totals", Boolean.toString(includeTotals));
         if (searchQuery != null) {
-            builder.setParameter("search_engine", "v2");
+            builder.setParameter("search_engine", "v3");
             builder.setParameter("q", searchQuery + " AND " + defaultQuery);
         }
         else {
-            builder.setParameter("search_engine", "v2");
+            builder.setParameter("search_engine", "v3");
             builder.setParameter("q", defaultQuery);
         }
 


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [ ] All tests and CI builds passing

### Description

New Auth0 Users cannot use the user search v2, currently used by `Auth0Users.java`. This PR simply changes the used version to v3.

As documented in https://auth0.com/docs/users/search/v2:
> User search v2 has been deprecated as of June 6th 2018. Tenants created after this date will not have the option of using it. We recommend that you use User Search v3 instead.

The used query works with v2 and v3 and doesn't need to be adjusted.


